### PR TITLE
Fix server shutdown process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# log file
+swaggo-language-server.log

--- a/swaggo-language-server/internal/handler/cancel_request.go
+++ b/swaggo-language-server/internal/handler/cancel_request.go
@@ -1,0 +1,23 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/takaaa220/swaggo-ide/swaggo-language-server/internal/handler/protocol"
+	"golang.org/x/exp/jsonrpc2"
+)
+
+func (h *LSPHandler) HandleCancelRequest(ctx context.Context, req *jsonrpc2.Request) error {
+	var params protocol.CancelParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return protocol.NewResponseError(protocol.CodeInvalidParams, err.Error(), nil)
+	}
+
+	return h.doCancel(ctx, &params)
+}
+
+func (h *LSPHandler) doCancel(_ context.Context, p *protocol.CancelParams) error {
+	h.conn.Cancel(p.ID)
+	return nil
+}

--- a/swaggo-language-server/internal/handler/logger.go
+++ b/swaggo-language-server/internal/handler/logger.go
@@ -6,20 +6,20 @@ import (
 )
 
 type logger struct {
-	level          logLevel
+	level          LogLevel
 	internalLogger *log.Logger
 }
 
-type logLevel int
+type LogLevel int
 
 const (
-	LogDebug logLevel = iota
+	LogDebug LogLevel = iota
 	LogInfo
 	LogWarn
 	LogError
 )
 
-func NewLogger(writer io.Writer, level logLevel) *logger {
+func NewLogger(writer io.Writer, level LogLevel) *logger {
 	return &logger{
 		level:          level,
 		internalLogger: log.New(writer, "", log.LstdFlags),

--- a/swaggo-language-server/internal/handler/protocol/cancel_request.go
+++ b/swaggo-language-server/internal/handler/protocol/cancel_request.go
@@ -1,0 +1,33 @@
+package protocol
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"golang.org/x/exp/jsonrpc2"
+)
+
+type CancelParams struct {
+	ID jsonrpc2.ID `json:"id"` // string | int64
+}
+
+func (c *CancelParams) UnmarshalJSON(b []byte) error {
+	p := struct {
+		ID any `json:"id"`
+	}{}
+
+	if err := json.Unmarshal(b, &p); err != nil {
+		return err
+	}
+
+	switch v := p.ID.(type) {
+	case string:
+		c.ID = jsonrpc2.StringID(v)
+	case float64:
+		c.ID = jsonrpc2.Int64ID(int64(v))
+	default:
+		return fmt.Errorf("invalid message id type <%T>%v", v, v)
+	}
+
+	return nil
+}

--- a/swaggo-language-server/internal/handler/shutdown.go
+++ b/swaggo-language-server/internal/handler/shutdown.go
@@ -6,11 +6,15 @@ import (
 	"golang.org/x/exp/jsonrpc2"
 )
 
-func (h *LSPHandler) HandleShutdown(_ context.Context, _ *jsonrpc2.Request) (any, error) {
+func (h *LSPHandler) HandleShutdown(_ context.Context, req *jsonrpc2.Request) error {
 	if h.checkSyntaxTimer != nil {
 		h.checkSyntaxTimer.Stop()
 	}
 
-	close(h.checkSyntaxReq)
-	return nil, h.CloseConnection()
+	h.logger.Debugf("Shutdown request received")
+	h.shutdownChan <- struct{}{}
+	h.CloseConnection()
+	h.logger.Debugf("Shutdown completed")
+
+	return nil
 }

--- a/swaggo-language-server/internal/handler/transport/binder.go
+++ b/swaggo-language-server/internal/handler/transport/binder.go
@@ -26,7 +26,7 @@ func NewBinder(handler Handler) *binder {
 }
 
 func (b *binder) Bind(ctx context.Context, conn *jsonrpc2.Connection) (jsonrpc2.ConnectionOptions, error) {
-	// maybe, this is hack...
+	// FIXME: use ctx
 	b.handler.SetConnection(conn)
 
 	return jsonrpc2.ConnectionOptions{

--- a/swaggo-language-server/internal/handler/transport/stdio.go
+++ b/swaggo-language-server/internal/handler/transport/stdio.go
@@ -1,6 +1,7 @@
 package transport
 
 import (
+	"fmt"
 	"io"
 	"os"
 )
@@ -18,9 +19,14 @@ func (stdrwc) Write(p []byte) (int, error) {
 }
 
 func (stdrwc) Close() error {
-	if err := os.Stdin.Close(); err == nil {
-		return os.Stdout.Close()
-	} else {
-		return err
+	stdinErr := os.Stdin.Close()
+	stdoutErr := os.Stdout.Close()
+
+	if stdinErr != nil && stdoutErr != nil {
+		return fmt.Errorf("stdin error: %v, stdout error: %v", stdinErr, stdoutErr)
 	}
+	if stdinErr != nil {
+		return stdinErr
+	}
+	return stdoutErr
 }

--- a/swaggo-language-server/internal/server.go
+++ b/swaggo-language-server/internal/server.go
@@ -2,32 +2,66 @@ package internal
 
 import (
 	"context"
-	"log"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/takaaa220/swaggo-ide/swaggo-language-server/internal/handler"
 	"github.com/takaaa220/swaggo-ide/swaggo-language-server/internal/handler/transport"
 	"golang.org/x/exp/jsonrpc2"
 )
 
-func StartServer(ctx context.Context, debug bool) error {
+func RunServer(debug bool) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// TODO: refactor for options
 	opts := handler.LSPHandlerOptions{
-		LogLevel: handler.LogWarn,
+		CheckSyntaxDebounce: 100 * time.Millisecond,
+		LogLevel:            handler.LogWarn,
+		LogWriter:           os.Stderr,
 	}
 	if debug {
 		opts.LogLevel = handler.LogDebug
+
+		logWriter, err := os.OpenFile("swaggo-language-server.log", os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+		if err != nil {
+			return err
+		}
+		defer logWriter.Close()
+		opts.LogWriter = logWriter
 	}
 
-	handler := handler.NewLSPHandler(opts)
+	shutdownChan := make(chan struct{})
+	defer close(shutdownChan)
 
+	handler := handler.NewLSPHandler(ctx, shutdownChan, opts)
 	binder := transport.NewBinder(handler)
 	listener := transport.NewStdListener()
 
-	server, err := jsonrpc2.Serve(ctx, listener, binder)
+	server, err := jsonrpc2.Serve(ctx, jsonrpc2.NewIdleListener(20*time.Second, listener), binder)
 	if err != nil {
 		return err
 	}
 
-	log.Println("Server started")
+	fmt.Fprintln(opts.LogWriter, "Server started")
 
-	return server.Wait()
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigChan)
+
+	select {
+	case <-sigChan:
+	case <-shutdownChan:
+		cancel()
+	case <-ctx.Done():
+	}
+
+	// wait for graceful shutdown
+	fmt.Fprintln(opts.LogWriter, "Waiting for server to shut down...")
+	server.Wait()
+	fmt.Fprintln(opts.LogWriter, "Server stopped")
+	return nil
 }

--- a/swaggo-language-server/internal/tests/helper.go
+++ b/swaggo-language-server/internal/tests/helper.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log"
+	"os"
 	"sync"
 	"testing"
 
@@ -44,7 +45,10 @@ func runServer() *testServer {
 		log.Fatal(err)
 	}
 
-	binder := transport.NewBinder(handler.NewLSPHandler(handler.LSPHandlerOptions{LogLevel: handler.LogDebug}))
+	shutdownChan := make(chan struct{})
+	defer close(shutdownChan)
+
+	binder := transport.NewBinder(handler.NewLSPHandler(ctx, shutdownChan, handler.LSPHandlerOptions{LogLevel: handler.LogDebug, LogWriter: os.Stderr}))
 
 	server := &testServer{
 		cancel:   cancel,

--- a/swaggo-language-server/main.go
+++ b/swaggo-language-server/main.go
@@ -1,12 +1,10 @@
 package main
 
 import (
-	_ "net/http/pprof"
-
 	"context"
-	"fmt"
 	"log"
 	"net/http"
+	_ "net/http/pprof"
 
 	"github.com/takaaa220/swaggo-ide/swaggo-language-server/internal"
 )
@@ -20,9 +18,9 @@ func main() {
 		}()
 	}
 
-	ctx := context.Background()
-
-	if err := internal.StartServer(ctx, debug); err != nil {
-		log.Fatal(fmt.Errorf("failed to start server: %w", err))
+	if err := internal.RunServer(debug); err != nil {
+		if err != context.Canceled {
+			log.Printf("failed to start server: %v", err)
+		}
 	}
 }


### PR DESCRIPTION
Improve the bug that don't stop server even if shutdown request is received.
(But the bug may be remaining...)

Prerequisite knowledge:
- VSCode sends shutdown event when reloading window, close app and so on
- (maybe) VSCode may not stop a language server process
- jsonrpc2 doesn't stop until all active connections are closed when close context

Changes:
- Add timeout to Handle
- Do as follows when received signal and received shutdown event from client:
  - Close the connection
  - Close the channel
  - Stop timer
- Add debug log in vscode extension