### PR TITLE
Fix shutdown handling to prevent panic and goroutine leaks

### DIFF
--- a/swaggo-language-server/internal/handler/check_syntax_test.go
+++ b/swaggo-language-server/internal/handler/check_syntax_test.go
@@ -1,0 +1,111 @@
+package handler
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/takaaa220/swaggo-ide/swaggo-language-server/internal/logger"
+)
+
+func TestMain(m *testing.M) {
+	logger.Setup(os.Stderr, logger.LogDebug)
+	os.Exit(m.Run())
+}
+
+func TestCheckSyntax_ShutdownDuringTimer(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	h := &LSPHandler{
+		checkSyntaxDebounce: 100 * time.Millisecond,
+		checkSyntaxReq:      make(chan checkSyntaxRequest),
+		cancel:              cancel,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		h.checkSyntax(ctx)
+		close(done)
+	}()
+
+	// Set timer
+	h.requestCheckSyntax("file:///test.go", "package main")
+
+	// Cancel before timer fires
+	cancel()
+
+	// Wait for checkSyntax goroutine to finish (confirms no panic)
+	select {
+	case <-done:
+		// success
+	case <-time.After(1 * time.Second):
+		t.Fatal("checkSyntax did not shutdown in time")
+	}
+}
+
+func TestCheckSyntax_TimerFiresAfterShutdown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	h := &LSPHandler{
+		checkSyntaxDebounce: 10 * time.Millisecond,
+		checkSyntaxReq:      make(chan checkSyntaxRequest),
+		cancel:              cancel,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		h.checkSyntax(ctx)
+		close(done)
+	}()
+
+	// Set timer with very short debounce
+	h.requestCheckSyntax("file:///test.go", "package main")
+
+	// Wait for timer to fire and try to send
+	time.Sleep(15 * time.Millisecond)
+
+	// Cancel after timer has fired but possibly before send completes
+	cancel()
+
+	// Wait for checkSyntax goroutine to finish (confirms no panic)
+	select {
+	case <-done:
+		// success
+	case <-time.After(1 * time.Second):
+		t.Fatal("checkSyntax did not shutdown in time")
+	}
+}
+
+func TestCheckSyntax_MultipleRequestsThenShutdown(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	h := &LSPHandler{
+		checkSyntaxDebounce: 5 * time.Millisecond,
+		checkSyntaxReq:      make(chan checkSyntaxRequest),
+		cancel:              cancel,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		h.checkSyntax(ctx)
+		close(done)
+	}()
+
+	// Send multiple requests rapidly
+	for i := 0; i < 10; i++ {
+		h.requestCheckSyntax("file:///test.go", "package main")
+		time.Sleep(1 * time.Millisecond)
+	}
+
+	// Cancel while timers might be firing
+	cancel()
+
+	// Wait for checkSyntax goroutine to finish (confirms no panic)
+	select {
+	case <-done:
+		// success
+	case <-time.After(1 * time.Second):
+		t.Fatal("checkSyntax did not shutdown in time")
+	}
+}


### PR DESCRIPTION
## Summary
- Fix panic when timer sends to closed channel during shutdown
- Fix goroutines running independently from parent context
- Add shutdown timeout (5s) to prevent indefinite blocking
- Add tests for shutdown scenarios

## Changes
- `check_syntax.go`: Add mutex and closed flag for safe shutdown handling
- `handler.go`: Add nil check for `h.conn` in timeout handler
- `server.go`: Add shutdown timeout with forced exit
- `check_syntax_test.go`: Add shutdown scenario tests

## Test plan
- [x] Verify no race conditions with `go test -race ./...`
- [x] Verify all tests pass
- [ ] Verify process terminates properly with Ctrl+C

Fixes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved syntax checking reliability with better handling of concurrent requests and cancellation scenarios.
  * Enhanced server shutdown behavior with timeout protection to ensure graceful termination.

* **Tests**
  * Added comprehensive test coverage for syntax checking under various shutdown and debounce scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->