### PR TITLE
chore: bump VSCode extension version to 0.0.9

### DIFF
--- a/vscode_client/package.json
+++ b/vscode_client/package.json
@@ -2,7 +2,7 @@
   "name": "swaggo-language-server-client",
   "displayName": "Swaggo Language Server Client",
   "description": "A VSCode extension for Swaggo",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "publisher": "takaaa220",
   "engines": {
     "vscode": "^1.95.0"


### PR DESCRIPTION
## Summary
- Update VSCode extension version from 0.0.8 to 0.0.9

## Why
Align the package.json version with the release tag version for the VSCode Marketplace publishing workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated VSCode extension client version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->